### PR TITLE
fix(package.json): updated list of files to publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,11 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist/index.js",
+    "dist/utils.js",
     "dist/index.d.ts",
-    "dist/esm/index.js"
+    "dist/utils.d.ts",
+    "dist/esm/index.js",
+    "dist/esm/utils.js"
   ],
   "scripts": {
     "clean": "rimraf coverage dist *.log* redux-mock-store-*",


### PR DESCRIPTION
I was not aware that it requires to make an entry under "files" in package.json to publish those files in npm